### PR TITLE
apply arguments of in super

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@ import {render} from 'react-dom';
 
 class Main extends React.Component {
     constructor() {
-        super();
+        super(...arguments);
         this.state = {
             clickCount: 0,
         };


### PR DESCRIPTION
It's for not omitting `context` argument which used by libraries as `redux`
and anyway it's a good habit because you won't always know whole the arguments that are passed in the `constructor`
